### PR TITLE
Fix POD encoding in Test::Database::Driver::mysql.

### DIFF
--- a/lib/Test/Database/Driver/mysql.pm
+++ b/lib/Test/Database/Driver/mysql.pm
@@ -51,6 +51,8 @@ sub databases {
 
 __END__
 
+=encoding utf8
+
 =head1 NAME
 
 Test::Database::Driver::mysql - A Test::Database driver for mysql
@@ -74,7 +76,7 @@ Philippe Bruhat (BooK), C<< <book@cpan.org> >>
 
 =head1 ACKNOWLEDGEMENTS
 
-Many thanks to Kristian Köhntopp who helped me while writing a
+Many thanks to Kristian KÃ¶hntopp who helped me while writing a
 previous version of this module (before C<Test::Database> 0.03).
 
 =head1 COPYRIGHT


### PR DESCRIPTION
Fixes this test failure on 5.17.6:

t/pod.t .................. 1/11 
# Failed test 'POD test for blib/lib/Test/Database/Driver/mysql.pm'
# at /home/racke/perl5/perlbrew/perls/perl-5.17.6/lib/site_perl/5.17.6/Test/Pod.pm line 182.
# blib/lib/Test/Database/Driver/mysql.pm (77): Non-ASCII character seen before =encoding in 'K�hntopp'. Assuming ISO8859-1
# Looks like you failed 1 test of 11.

t/pod.t .................. Dubious, test returned 1 (wstat 256, 0x100)

Regards
                 Racke
