### PR TITLE
Fix RT #93705:

### DIFF
--- a/lib/Test/Database/Driver/CSV.pm
+++ b/lib/Test/Database/Driver/CSV.pm
@@ -16,14 +16,16 @@ sub _version { return Text::CSV_XS->VERSION; }
 sub dsn {
     my ( $self, $dbname ) = @_;
     my $dbdir = File::Spec->catdir( $self->base_dir(), $dbname );
-    mkpath( [$dbdir] );
+    $self->{'_created_dir'} = mkpath( [$dbdir] );
     return $self->make_dsn( f_dir => $dbdir );
 }
 
 sub drop_database {
     my ( $self, $dbname ) = @_;
     my $dbdir = File::Spec->catdir( $self->base_dir(), $dbname );
-    rmtree( [$dbdir] );
+    if ( $self->{'_created_dir'} ) {
+        rmtree( [$dbdir] );
+    }
 }
 
 'CSV';


### PR DESCRIPTION
Test::Database uses File::Path::mkpath() which returns the
directory if it created it. Saving it in $self and then checking
it to decide whether to delete the directory or not.

I'm not sure this is good enough, since the directory could have
already existed and then we don't delete anything.

If DBD::CSV provided any information on what files were created,
or if we had any introspection to the "CREATE" statements, then
we might take care of it with finer detail and cover both cases.
